### PR TITLE
Add swap feature for current and destination field in maps page

### DIFF
--- a/maps.html
+++ b/maps.html
@@ -98,7 +98,7 @@
             </div>
             <div>
               <!-- This feature is completed successfully, just frontend part is left, will be completed soon -->
-              <a id="swap" class="btn-get-started" style="display:none;color:#fff;border:none;margin:0;width:50px; cursor:pointer;z-index: 2;"><svg
+              <a id="swap" class="btn-get-started" style="display: flexbox;color:#fff;border:none;margin:0;width:50px; cursor:pointer;z-index: 2;"><svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 512 512" height="60" fill="white">
                 <path 


### PR DESCRIPTION
Fixes #34 
1. This PR adds a new feature in the maps page of the class locater.
2. Added a swap button to make it easy for the user to swap between the current and destination field in just one click.
3. User need not to type the same names of locations twice in two different textboxes, rather if the locations are to be interchanged, they can simply click the swap button.
Here's how the feature looks :
![Screenshot 2025-04-02 224044](https://github.com/user-attachments/assets/aa071305-0077-4d6d-8614-fa5593def508)
![Screenshot 2025-04-02 224059](https://github.com/user-attachments/assets/bc30da35-f5da-42d3-88a8-487c346a5555)

